### PR TITLE
feat: add Tavily as configurable web search option alongside DuckDuckGo

### DIFF
--- a/chatgpt_linebot/modules/web_search.py
+++ b/chatgpt_linebot/modules/web_search.py
@@ -21,6 +21,8 @@ import requests
 from bs4 import BeautifulSoup
 from duckduckgo_search import DDGS
 
+from config import TAVILY_API_KEY
+
 # Rotate user-agent to reduce blocking
 _USER_AGENTS = [
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
@@ -30,6 +32,27 @@ _USER_AGENTS = [
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
 ]
+
+
+def _tavily_search(query: str, max_results: int) -> list[dict]:
+    """Search using Tavily API (cloud-friendly, requires TAVILY_API_KEY)."""
+    try:
+        from tavily import TavilyClient
+
+        client = TavilyClient(api_key=TAVILY_API_KEY)
+        response = client.search(query=query, max_results=max_results)
+        results = []
+        for r in response.get("results", []):
+            results.append({
+                "title": r.get("title", ""),
+                "body": r.get("content", ""),
+                "href": r.get("url", ""),
+            })
+        print(f"[Tavily] results count: {len(results)}")
+        return results
+    except Exception as e:
+        print(f"[Tavily] error: {e}")
+        return []
 
 
 def _format_results(results: list[dict]) -> str:
@@ -93,6 +116,13 @@ def web_search(query: str, max_results: int = 5) -> str:
     Returns:
         A formatted string containing search results (title + snippet + url).
     """
+    # Try Tavily first when API key is available
+    if TAVILY_API_KEY:
+        results = _tavily_search(query, max_results)
+        if results:
+            print("[web_search] Used backend: Tavily")
+            return _format_results(results)
+
     with DDGS() as ddgs:
         for name, search_fn in [
             ("DDG-HTML", _search_ddg_html),
@@ -192,6 +222,13 @@ def deep_web_search(
     Returns:
         A formatted string with full page content for each search result.
     """
+    # Try Tavily first when API key is available
+    if TAVILY_API_KEY:
+        results = _tavily_search(query, max_results)
+        if results:
+            print("[deep_web_search] Used backend: Tavily")
+            return _format_deep_results(results, max_chars_per_page)
+
     with DDGS() as ddgs:
         for name, search_fn in [
             ("DDG-HTML", _search_ddg_html),

--- a/config.py
+++ b/config.py
@@ -15,5 +15,8 @@ SERPAPI_API_KEY = os.environ.get('SERPAPI_API_KEY')
 # RAPID API
 RAPID = os.environ.get('RAPID')
 
+# Tavily (optional, for web search)
+TAVILY_API_KEY = os.environ.get('TAVILY_API_KEY')
+
 # ZHIPUAI API
 GPT_API_KEY = os.environ.get('GPT_API_KEY')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ google-search-results = "^2.4.2"
 cloudscraper = "^1.2.71"
 zhipuai = "*"
 duckduckgo-search = "^8.1.1"
+tavily-python = {version = ">=0.3.0", optional = true}
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary

Adds Tavily as a preferred web search backend when `TAVILY_API_KEY` is configured, while keeping the existing DuckDuckGo fallback chain fully intact.

**Why:** DuckDuckGo's Bing backend gets blocked on cloud IPs (Render, Railway). Tavily provides a reliable, cloud-friendly search API designed for LLM applications.

**How it works:**
- If `TAVILY_API_KEY` is set → try Tavily first
- If Tavily fails or key is absent → fall back to DDG HTML → DDG Lite → DDG Default (unchanged)
- Zero-config backward compatibility: no env var = existing behavior

## Files Changed

- `chatgpt_linebot/modules/web_search.py` — Added `_tavily_search()` helper; updated `web_search()` and `deep_web_search()` to try Tavily first when API key is present
- `config.py` — Added `TAVILY_API_KEY` env var loading
- `pyproject.toml` — Added `tavily-python` as optional dependency

## Dependency Changes

- Added `tavily-python >= 0.3.0` (optional) to `pyproject.toml`

## Environment Variable Changes

- Added optional `TAVILY_API_KEY` — set to enable Tavily search; omit to use DDG only

## Notes for Reviewers

- Tavily import is deferred (inside `_tavily_search()`) so the package is only required when actually used
- All existing DDG code paths are untouched
- Result format is normalized to `{title, body, href}` to match the existing DDG format


### Automated Review

- Passed after 1 attempt(s)
- Final review: The migration correctly adds Tavily as a preferred web search provider with graceful fallback to the existing DDG chain. API patterns, guard logic, lazy imports, and config changes are all sound. Three minor issues were found: the pyproject.toml optional dependency lacks a Poetry extras group, the module docstring is outdated, and README/function docstrings don't mention the new Tavily path. None of these block functionality.
