### PR TITLE
feat: add Tavily Extract as fallback image search provider

### DIFF
--- a/chatgpt_linebot/modules/agent.py
+++ b/chatgpt_linebot/modules/agent.py
@@ -222,6 +222,9 @@ def _dispatch_tool(
             if not url:
                 crawler2 = ImageCrawler(engine="serpapi", nums=5, api_key=config.SERPAPI_API_KEY)
                 url = crawler2.get_url(query)
+            if not url and getattr(config, 'TAVILY_API_KEY', None):
+                crawler3 = ImageCrawler(engine="tavily", nums=5, api_key=config.TAVILY_API_KEY)
+                url = crawler3.get_url(query)
             if url:
                 result.image_url = url
                 return f"✅ Image found: {url}"

--- a/chatgpt_linebot/modules/image_crawler.py
+++ b/chatgpt_linebot/modules/image_crawler.py
@@ -104,12 +104,41 @@ class ImageCrawler:
 
         return img_urls[:self.nums]
 
+    def _tavily_extract(self, search_query: str) -> list[str]:
+        """Use Tavily Extract to fetch image URLs from a Google Images search page."""
+        from tavily import TavilyClient
+        import urllib.parse
+
+        encoded_query = urllib.parse.quote_plus(search_query)
+        google_images_url = f"https://www.google.com/search?q={encoded_query}&tbm=isch"
+
+        client = TavilyClient(api_key=self.api_key)
+        response = client.extract(
+            urls=[google_images_url],
+            include_images=True,
+        )
+
+        urls = []
+        for result in response.get("results", []):
+            for img_url in result.get("images", []):
+                urls.append(img_url)
+                if len(urls) >= self.nums:
+                    break
+            if len(urls) >= self.nums:
+                break
+
+        return urls[:self.nums]
+
     def get_url(self, search_query: str) -> str:
         try:
             if self.engine == 'icrawler':
                 urls = self._icrawler(search_query)
             elif self.engine == 'serpapi':
                 urls = self._serpapi(search_query)
+            elif self.engine == 'tavily':
+                urls = self._tavily_extract(search_query)
+            else:
+                urls = []
 
             for url in urls:
                 if self._is_img_url(url):

--- a/config.py
+++ b/config.py
@@ -15,5 +15,8 @@ SERPAPI_API_KEY = os.environ.get('SERPAPI_API_KEY')
 # RAPID API
 RAPID = os.environ.get('RAPID')
 
+# Tavily API (optional, used for web search and image extraction)
+TAVILY_API_KEY = os.environ.get('TAVILY_API_KEY')
+
 # ZHIPUAI API
 GPT_API_KEY = os.environ.get('GPT_API_KEY')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ google-search-results = "^2.4.2"
 cloudscraper = "^1.2.71"
 zhipuai = "*"
 duckduckgo-search = "^8.1.1"
+tavily-python = ">=0.3.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary

Adds Tavily Extract as a third fallback option for image search, alongside the existing iCrawler and SerpAPI providers. This is an **additive** change — existing providers are untouched.

### What changed

- **`chatgpt_linebot/modules/image_crawler.py`**: Added `_tavily_extract()` method to `ImageCrawler` that uses `TavilyClient.extract()` with `include_images=True` on a constructed Google Images URL. Registered `'tavily'` as a valid engine in `get_url()`.
- **`chatgpt_linebot/modules/agent.py`**: Added a third fallback in the `search_image` tool dispatch. When both iCrawler and SerpAPI return no results and `TAVILY_API_KEY` is configured, a Tavily-based crawler is tried.
- **`config.py`**: Added `TAVILY_API_KEY` environment variable reference.
- **`pyproject.toml`**: Added `tavily-python >= 0.3.0` dependency.

### Dependency changes

- Added `tavily-python >= 0.3.0` to `pyproject.toml`

### Environment variable changes

- Added optional `TAVILY_API_KEY` env var in `config.py`

### Notes for reviewers

- The Tavily path only activates when `TAVILY_API_KEY` is set and both iCrawler and SerpAPI fail — zero impact on existing behavior.
- SerpAPI dependencies and `SERPAPI_API_KEY` remain unchanged.
- `tavily-python` may already be present if the web-search migration unit was applied first.


### Automated Review

- Passed after 1 attempt(s)
- Final review: The implementation correctly adds Tavily Extract as a third fallback for image search. All four files from the plan are modified. The Tavily SDK usage follows correct patterns, the fallback chain in agent.py is sound, and empty/error responses are handled gracefully. The config.py and pyproject.toml changes overlap with the prerequisite unit (web-search-ddg-to-tavily) but are idempotent and acceptable. No regressions were introduced — in fact, the new `else: urls = []` branch in `get_url()` fixes a latent NameError for unknown engines.
